### PR TITLE
Removed duplicate code

### DIFF
--- a/src/octi/config/ConfigReader.cpp
+++ b/src/octi/config/ConfigReader.cpp
@@ -43,7 +43,7 @@ void ConfigReader::help(const char* bin) const {
             << "print version\n"
             << std::setw(39) << "  -h [ --help ]"
             << "show this help message\n"
-            << std::setw(39) << "  -o [ --optim-mode ] arg (=heur)"
+            << std::setw(39) << "  -m [ --optim-mode ] arg (=heur)"
             << "optimization mode, 'heur' or 'ilp'\n"
             << std::setw(39) << "  --obstacles arg"
             << "GeoJSON file containing obstacle polygons\n"

--- a/src/transitmap/config/ConfigReader.cpp
+++ b/src/transitmap/config/ConfigReader.cpp
@@ -75,8 +75,6 @@ void ConfigReader::help(const char* bin) const {
             << "input line smoothing\n"
             << std::setw(37) << "  --random-colors"
             << "fill missing colors with random colors\n"
-            << std::setw(37) << "  --no-render-stations"
-            << "don't render stations\n"
             << std::setw(37) << "  --tight-stations"
             << "don't expand node fronts for stations\n"
             << std::setw(37) << "  --no-render-stations"


### PR DESCRIPTION
Hey,
I love your tools! 
While I was using it, I noticed the `--no-render-stations` argument was duplicate in `transitmap -h` (see below).
I assume it was just a copy paste accident, so I went ahead and just delete the first occurence.

```
>> transitmap -h
transitmap (part of LOOM) -128-NOTFOUND
(built Aug 16 2023 12:11:21)

(C) 2017-2023 University of Freiburg - Chair of Algorithms and Data Structures
Authors: Patrick Brosi <brosi@informatik.uni-freiburg.de>

Usage: transitmap < linegraph.json

Allowed options:

General:
  -v [ --version ]                   print version
  -h [ --help ]                      show this help message
  --render-engine arg (=svg)         Render engine, only 'svg' supported
  --line-width arg (=20)             width of a single transit line
  --line-spacing arg (=10)           spacing between transit lines
  --outline-width arg (=1)           width of line outlines
  --render-dir-markers               render line direction markers
  -l [ --labels ]                    render labels
  --line-label-textsize arg (=40)    textsize for line labels
  --station-label-textsize arg (=60) textsize for station labels
  --no-deg2-labels                   no labels for deg-2 stations
Misc:
  -D [ --from-dot ]                  input is in dot format
  --padding arg (=-1)                padding, -1 for auto
  --smoothing arg (=1)               input line smoothing
  --random-colors                    fill missing colors with random colors
  --no-render-stations               don't render stations
  --tight-stations                   don't expand node fronts for stations
  --no-render-stations               don't render stations
  --no-render-node-connections       don't render inner node connections
  --render-node-fronts               render node fronts
  --print-stats                      write stats to stdout
```